### PR TITLE
Replace @OneOfType with @Alternation and @Alternative

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/TopicOperatorSpec.java
@@ -17,7 +17,7 @@ import lombok.EqualsAndHashCode;
  * Representation of a Strimzi-managed Topic Operator deployment.
  */
 @Deprecated
-@DeprecatedType(replacedWithType = "io.strimzi.api.kafka.model.EntityTopicOperatorSpec")
+@DeprecatedType(replacedWithType = io.strimzi.api.kafka.model.EntityTopicOperatorSpec.class)
 @Buildable(
         editableEnabled = false,
         builderPackage = Constants.FABRIC8_KUBERNETES_API

--- a/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
+++ b/crd-annotations/src/main/java/io/strimzi/api/annotations/DeprecatedType.java
@@ -15,5 +15,5 @@ public @interface DeprecatedType {
     /**
      * @return The type which should be used as replacement
      */
-    String replacedWithType();
+    Class<?> replacedWithType();
 }

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/Property.java
@@ -4,16 +4,6 @@
  */
 package io.strimzi.crdgenerator;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.CustomResource;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
@@ -26,6 +16,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -297,6 +299,13 @@ class Property implements AnnotatedElement {
 
     boolean isDiscriminator() {
         return getName().equals(discriminator(m.getDeclaringClass()));
+    }
+
+    List<Property> getAlternatives() {
+        List<Property> alternatives =
+                Property.properties(getType().getType()).values().stream()
+                        .filter(p -> p.getAnnotation(Alternative.class) != null).collect(Collectors.toList());
+        return alternatives;
     }
 
     @Override

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternation.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternation.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.crdgenerator.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for classes which represent a choice between two or more possibilities identified by the
+ * {@link Alternative}-annotated properties of the annotated class.
+ * The JSON schema generated uses a {@code oneOf} constraint to force the choice between the alternative properties.
+ * The annotated class will typically need to have custom Jackson serialization which can determine from the serialized
+ * form which of the alternatives to deserialize.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Alternation {
+}

--- a/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternative.java
+++ b/crd-generator/src/main/java/io/strimzi/crdgenerator/annotations/Alternative.java
@@ -9,20 +9,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * One of several alternatives in an {@link Alternation}-annotated class.
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
-public @interface OneOfType {
-    /** @return List of alternatives */
-    Alternative[] value();
-
-    @interface Alternative {
-        @interface Field {
-            /** @return The name of a field */
-            String value();
-        }
-
-        /** @return Fields in this alternative */
-        Field[] value();
-    }
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface Alternative {
 }
-

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/DocGeneratorTest.java
@@ -15,6 +15,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DocGeneratorTest {
 
@@ -25,6 +26,6 @@ public class DocGeneratorTest {
         DocGenerator crdGenerator = new DocGenerator(1, singletonList(ExampleCrd.class), w, new KubeLinker("{KubeApiReferenceBase}"));
         crdGenerator.generate(ExampleCrd.class);
         String s = w.toString();
-        assertThat(s, is(CrdTestUtils.readResource("simpleTest.adoc")));
+        assertEquals(CrdTestUtils.readResource("simpleTest.adoc"), s);
     }
 }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/ExampleCrd.java
@@ -16,7 +16,6 @@ import io.strimzi.crdgenerator.annotations.Example;
 import io.strimzi.crdgenerator.annotations.KubeLink;
 import io.strimzi.crdgenerator.annotations.Minimum;
 import io.strimzi.crdgenerator.annotations.OneOf;
-import io.strimzi.crdgenerator.annotations.OneOfType;
 import io.strimzi.crdgenerator.annotations.Pattern;
 
 import java.util.List;
@@ -281,7 +280,6 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.affinity = affinity;
     }
 
-    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("mapValue")), @OneOfType.Alternative(@OneOfType.Alternative.Field("listValue"))})
     public MapOrList getAlternatives() {
         return alternatives;
     }
@@ -290,7 +288,6 @@ public class ExampleCrd<T, U extends Number, V extends U> extends CustomResource
         this.alternatives = alternatives;
     }
 
-    @OneOfType({@OneOfType.Alternative(@OneOfType.Alternative.Field("type1Value")), @OneOfType.Alternative(@OneOfType.Alternative.Field("type2Value"))})
     public Type1OrType2 getTypedAlternatives() {
         return typedAlternatives;
     }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/MapOrList.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.strimzi.crdgenerator.annotations.Alternation;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.Map;
 
 @JsonDeserialize(using = MapOrList.Deserializer.class)
 @JsonSerialize(using = MapOrList.Serializer.class)
+@Alternation
 public class MapOrList {
     private Map<String, String> mapValue;
     private List<String> listValue;
@@ -38,10 +41,12 @@ public class MapOrList {
         listValue = list;
     }
 
+    @Alternative
     public Map<String, String> getMapValue()    {
         return mapValue;
     }
 
+    @Alternative
     public List<String> getListValue()    {
         return listValue;
     }

--- a/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
+++ b/crd-generator/src/test/java/io/strimzi/crdgenerator/Type1OrType2.java
@@ -18,11 +18,14 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.strimzi.api.annotations.DeprecatedType;
+import io.strimzi.crdgenerator.annotations.Alternation;
+import io.strimzi.crdgenerator.annotations.Alternative;
 
 import java.io.IOException;
 
 @JsonDeserialize(using = Type1OrType2.Deserializer.class)
 @JsonSerialize(using = Type1OrType2.Serializer.class)
+@Alternation
 public class Type1OrType2 {
     private Type1 type1Value;
     private Type2 type2Value;
@@ -37,10 +40,12 @@ public class Type1OrType2 {
         type2Value = type2Value;
     }
 
+    @Alternative
     public Type1 getMapValue()    {
         return type1Value;
     }
 
+    @Alternative
     public Type2 getListValue()    {
         return type2Value;
     }
@@ -88,7 +93,7 @@ public class Type1OrType2 {
     }
 
     @Deprecated
-    @DeprecatedType(replacedWithType = "io.strimzi.crdgenerator.Type1OrType2$Type2")
+    @DeprecatedType(replacedWithType = io.strimzi.crdgenerator.Type1OrType2.Type2.class)
     public class Type1 {
         private String key1;
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.adoc
@@ -10,7 +10,7 @@
 
 |{KubeApiReferenceBase}#affinity-v1-core[Affinity]
 |alternatives            1.2+<.<|
-|map or string array
+|string array or map
 |arrayOfBoundTypeVar     1.2+<.<|
 |xref:type-Number-{context}[`Number`] array
 |arrayOfBoundTypeVar2    1.2+<.<|
@@ -76,7 +76,7 @@
 |stringProperty          1.2+<.<|
 |string
 |typedAlternatives       1.2+<.<|
-|xref:type-Type1-{context}[`Type1`] or xref:type-Type2-{context}[`Type2`]
+|xref:type-Type2-{context}[`Type2`] or xref:type-Type1-{context}[`Type1`]
 |====
 
 [id='type-Number-{context}']
@@ -144,6 +144,19 @@ It must have the value `right` for the type `PolymorphicRight`.
 |string
 |====
 
+[id='type-Type2-{context}']
+# `Type2` schema reference
+
+Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
+
+
+[options="header"]
+|====
+|Property     |Description
+|key2  1.2+<.<|
+|string
+|====
+
 [id='type-Type1-{context}']
 # `Type1` schema reference
 
@@ -157,19 +170,6 @@ Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
 |====
 |Property     |Description
 |key1  1.2+<.<|
-|string
-|====
-
-[id='type-Type2-{context}']
-# `Type2` schema reference
-
-Used in: xref:type-ExampleCrd-{context}[`ExampleCrd`]
-
-
-[options="header"]
-|====
-|Property     |Description
-|key2  1.2+<.<|
 |string
 |====
 

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTest.yaml
@@ -238,10 +238,10 @@ spec:
                         type: "string"
         alternatives:
           oneOf:
-          - type: "object"
           - type: "array"
             items:
               type: "string"
+          - type: "object"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -437,11 +437,11 @@ spec:
           oneOf:
           - type: "object"
             properties:
-              key1:
+              key2:
                 type: "string"
           - type: "object"
             properties:
-              key2:
+              key1:
                 type: "string"
       oneOf:
       - properties:

--- a/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
+++ b/crd-generator/src/test/resources/io/strimzi/crdgenerator/simpleTestHelmMetadata.yaml
@@ -244,10 +244,10 @@ spec:
                         type: "string"
         alternatives:
           oneOf:
-          - type: "object"
           - type: "array"
             items:
               type: "string"
+          - type: "object"
         arrayOfBoundTypeVar:
           type: "array"
           items:
@@ -443,11 +443,11 @@ spec:
           oneOf:
           - type: "object"
             properties:
-              key1:
+              key2:
                 type: "string"
           - type: "object"
             properties:
-              key2:
+              key1:
                 type: "string"
       oneOf:
       - properties:


### PR DESCRIPTION
@scholzj I experimented with switching from `@OneOfType` on the property to `@Alternation` on the "alternation class" with the properties annotated with `@Alternative`. This feels much more natural to me and avoids things like the possibility of having repeats in the list of fields. Wdyt?

Signed-off-by: Tom Bentley <tbentley@redhat.com>
