### PR TITLE
[systemtest] Fix Admin client checks inside the builder

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaAdminClients.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/internalClients/KafkaAdminClients.java
@@ -80,10 +80,8 @@ public class KafkaAdminClients extends BaseClients {
     public void setAdminOperation(AdminClientOperation adminOperation) {
         if (adminOperation == null) {
             throw new InvalidParameterException("TopicOperation must be set.");
-        } else if ((this.getTopicName() == null || this.getTopicName().isEmpty())
-            && !(adminOperation.equals(AdminClientOperation.HELP) || adminOperation.equals(AdminClientOperation.LIST_TOPICS))) {
-            throw new InvalidParameterException("Topic name (or 'prefix' if topic count > 1) is not set.");
         }
+
         this.adminOperation = adminOperation;
     }
 
@@ -108,6 +106,11 @@ public class KafkaAdminClients extends BaseClients {
     }
 
     public Job defaultAdmin() {
+        if ((this.getTopicName() == null || this.getTopicName().isEmpty())
+            && !(this.getAdminOperation().equals(AdminClientOperation.HELP) || this.getAdminOperation().equals(AdminClientOperation.LIST_TOPICS))) {
+            throw new InvalidParameterException("Topic name (or 'prefix' if topic count > 1) is not set.");
+        }
+
         Map<String, String> adminLabels = new HashMap<>();
         adminLabels.put("app", adminName);
         adminLabels.put(Constants.KAFKA_ADMIN_CLIENT_LABEL_KEY, Constants.KAFKA_ADMIN_CLIENT_LABEL_VALUE);


### PR DESCRIPTION
Signed-off-by: Lukas Kral <lukywill16@gmail.com>

### Type of change

- Bugfix

### Description

This PR fixes handling of Admin Clients check after Sundrio update -> setters have different order inside the `build()` method than before - so the checks are always failing, because the values are not set.

### Checklist

- [ ] Make sure all tests pass


